### PR TITLE
Add composer replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,8 @@
         "psr-4": {
             "Stomp\\Tests\\": "tests/"
         }
+    },
+    "replace": {
+        "stomp-php/stomp-php": "5.0.*"
     }
 }


### PR DESCRIPTION
*Problem:* This package will not satisfy composer requirements for `stomp-php/stomp-php`. That can lead to both packages being installed together. This won't work of course, since both use the same PHP namespaces.

*Example:* There is a hard dependency on `invia-de/stomp-php` in a project's composer.json. At the same time, a library is added which requires `stomp-php/stomp-php`. Both packages will be installed.

This PR makes this project a replacement for the original package in the eyes of composer.